### PR TITLE
Configures cli build properly

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -10,7 +10,10 @@ module.exports = function(defaults) {
       ]
     },
     fingerprint: {
-     prepend: 'https://storage.googleapis.com/contributor-days-assets/'
+      prepend: '//storage.googleapis.com/contributor-days-assets/',
+      replaceExtensions: ['html', 'js', 'css', 'json'],
+      exclude: ['assets/assetMap.json'],
+      ignore: ['assets/assetMap.json']
     }
   });
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "ember-cli-deploy-gcloud": "0.2.2",
     "ember-cli-deploy-gcloud-storage": "0.1.2",
     "ember-cli-fastboot": "1.0.0-beta.13",
+    "ember-engines": "0.3.4",
     "ember-cli-google-fonts": "2.3.1",
     "ember-cli-htmlbars": "^1.0.10",
     "ember-cli-htmlbars-inline-precompile": "^0.3.3",


### PR DESCRIPTION
This PR configures the production build fingerprint so generated json files with data are fingerprinted excluding Fastboot's "assetMap.json".