### PR TITLE
Added fastboot#hostWhitelist to config

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -1,5 +1,7 @@
 /* jshint node: true */
 
+const storageHost = '//storage.googleapis.com';
+
 module.exports = function(environment) {
   var ENV = {
     modulePrefix: 'contributors-days',
@@ -24,6 +26,10 @@ module.exports = function(environment) {
     APP: {
       // Here you can pass flags/options to your application instance
       // when it is created
+    },
+    
+    fastboot: {
+      hostWhitelist: [storageHost, /^localhost:\d+$/]
     }
   };
 


### PR DESCRIPTION
This PR adds fastboot#hostWhitelist to config otherwise Fastboot would throw Error: `Unknown Error: Error: You are using Ember Data with no host defined in your adapter. This will attempt to use the host of the FastBoot request, which is not configured for the current host of this request. Please set the hostWhitelist property for in your environment.js. FastBoot Error: You must provide a hostWhitelist to retrieve the host`