### PR TITLE
Added cacheControl to files uploaded to Google Storage

### DIFF
--- a/config/deploy.js
+++ b/config/deploy.js
@@ -9,7 +9,10 @@ module.exports = function() {
     'gcloud-storage': {
       projectId: 'contributor-days',
       bucket: 'contributor-days-assets',
-      filePattern: '**/*.{js,css,png,gif,ico,jpg,map,xml,txt,svg,swf,eot,ttf,woff,woff2,json}'
+      filePattern: '**/*.{js,css,png,gif,ico,jpg,map,xml,txt,svg,swf,eot,ttf,woff,woff2,json}',
+      metadata: {
+        cacheControl: 'public, max-age=31536000'
+      }
     }
   };
 };

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "ember-cli-deploy": "1.0.0-beta.2",
     "ember-cli-deploy-build": "0.1.1",
     "ember-cli-deploy-gcloud": "0.3.3",
-    "ember-cli-deploy-gcloud-storage": "0.1.2",
+    "ember-cli-deploy-gcloud-storage": "taras/ember-cli-deploy-gcloud-storage#upload-metadata",
     "ember-cli-fastboot": "1.0.0-beta.13",
     "ember-engines": "0.3.4",
     "ember-cli-google-fonts": "2.3.1",
@@ -51,5 +51,6 @@
     "ember-resolver": "^2.0.3",
     "ember-writer": "this-dot/ember-writer#7e91f618da3344b1f20256c05e6f0818887dd48a",
     "loader.js": "^4.0.10"
-  }
+  },
+  "dependencies": {}
 }


### PR DESCRIPTION
This PR specifies cacheControl property for files uploaded to Google Storage. This configures Google Storage to tell browsers to cache assets for a long time.

I had to change [`ember-cli-deploy-gcloud-storage`](https://github.com/knownasilya/ember-cli-deploy-gcloud-storage/pull/6) to allow specifying metadata.

/cc @jorgelainfiesta 